### PR TITLE
[Feat, Fix] 버그 수정, LocationShareFeature UserAnnotationView Set, Observe 로직 변경 

### DIFF
--- a/Projects/App/Sources/Core/FirebaseNetworkCore/Interface/FireBaseServiceProtocol.swift
+++ b/Projects/App/Sources/Core/FirebaseNetworkCore/Interface/FireBaseServiceProtocol.swift
@@ -41,5 +41,5 @@ public protocol FireBaseServiceProtocol {
     func removeSharedLocationObserve() -> Single<Void> 
     
     func uploadImage(imageData: Data) -> Single<String>
-    func deleteImage(imageString: String) -> Single<Void> 
+    func deleteImage(path: String) -> Single<Void> 
 }

--- a/Projects/App/Sources/Core/FirebaseNetworkCore/Interface/FireBaseServiceProtocol.swift
+++ b/Projects/App/Sources/Core/FirebaseNetworkCore/Interface/FireBaseServiceProtocol.swift
@@ -41,4 +41,5 @@ public protocol FireBaseServiceProtocol {
     func removeSharedLocationObserve() -> Single<Void> 
     
     func uploadImage(imageData: Data) -> Single<String>
+    func deleteImage(imageString: String) -> Single<Void> 
 }

--- a/Projects/App/Sources/Core/FirebaseNetworkCore/Sources/FireBaseServiceImpl.swift
+++ b/Projects/App/Sources/Core/FirebaseNetworkCore/Sources/FireBaseServiceImpl.swift
@@ -491,4 +491,20 @@ public extension FireBaseServiceImpl {
             return Disposables.create()
         }
     }
+    
+    func deleteImage(imageString: String) -> Single<Void> {
+        return Single.create { single in
+            let imageName = imageString
+            let firebaseReference = Storage.storage().reference().child("\(imageName)")
+            
+            firebaseReference.delete { error in
+                guard let error else {
+                    single(.failure(FireStoreError.unknown))
+                    return
+                }
+                single(.success(()))
+            }
+            return Disposables.create()
+        }
+    }
 }

--- a/Projects/App/Sources/Core/FirebaseNetworkCore/Sources/FireBaseServiceImpl.swift
+++ b/Projects/App/Sources/Core/FirebaseNetworkCore/Sources/FireBaseServiceImpl.swift
@@ -492,9 +492,9 @@ public extension FireBaseServiceImpl {
         }
     }
     
-    func deleteImage(imageString: String) -> Single<Void> {
+    func deleteImage(path: String) -> Single<Void> {
         return Single.create { single in
-            let imageName = imageString
+            let imageName = path
             let firebaseReference = Storage.storage().reference().child("\(imageName)")
             
             firebaseReference.delete { error in

--- a/Projects/App/Sources/Data/Repositories/AuthRepository/Sources/AuthRepositoryImpl.swift
+++ b/Projects/App/Sources/Data/Repositories/AuthRepository/Sources/AuthRepositoryImpl.swift
@@ -21,7 +21,7 @@ public final class AuthRepositoryImpl: AuthRepositoryProtocol {
     
     public func checkUser(uid: String) -> Single<Bool> {
         self.tokenManager.save(token: uid, with: .userId)
-        
+        print("checkUser(uid:: \(uid)")
         return self.firebaseService.getDocument(
             collection: .users,
             field: "id",

--- a/Projects/App/Sources/Data/Repositories/ImageRepository/Interface/ImageRepositoryProtocol.swift
+++ b/Projects/App/Sources/Data/Repositories/ImageRepository/Interface/ImageRepositoryProtocol.swift
@@ -11,4 +11,6 @@ import RxSwift
 
 public protocol ImageRepositoryProtocol: AnyObject {
     func uploadImage(imageData: Data) -> Observable<String>
+    func deleteImage(imageString: String) -> Observable<Void> 
+    func deleteMyProfileImage() -> Observable<Void> 
 }

--- a/Projects/App/Sources/Data/Repositories/ImageRepository/Sources/ImageRepositoryImpl.swift
+++ b/Projects/App/Sources/Data/Repositories/ImageRepository/Sources/ImageRepositoryImpl.swift
@@ -22,4 +22,24 @@ public final class ImageRepositoryImpl: ImageRepositoryProtocol {
         self.fireBaseService.uploadImage(imageData: imageData)
             .asObservable()
     }
+    
+    public func deleteImage(imageString: String) -> Observable<Void> {
+        return self.fireBaseService.deleteImage(imageString: imageString)
+            .asObservable()
+    }
+    
+    public func deleteMyProfileImage() -> Observable<Void> {
+        guard let id = self.tokenManager.getToken(with: .userId)
+        else { return .error(TokenManagerError.notFound) }
+        
+        return self.fireBaseService.getDocument(collection: .users, document: id)
+            .asObservable()
+            .map { $0.toObject(UserDTO.self)?.toEntity() }
+            .compactMap { $0?.profileImage }
+            .withUnretained(self)
+            .flatMap { owner, imageString in
+                owner.deleteImage(imageString: imageString)
+            }
+            .catchAndReturn(())
+    }
 }

--- a/Projects/App/Sources/Data/Repositories/ImageRepository/Sources/ImageRepositoryImpl.swift
+++ b/Projects/App/Sources/Data/Repositories/ImageRepository/Sources/ImageRepositoryImpl.swift
@@ -24,7 +24,8 @@ public final class ImageRepositoryImpl: ImageRepositoryProtocol {
     }
     
     public func deleteImage(imageString: String) -> Observable<Void> {
-        return self.fireBaseService.deleteImage(imageString: imageString)
+        guard let path = imageString.extractFilePath() else { return .error(LocalError.transformType) }
+        return self.fireBaseService.deleteImage(path: path)
             .asObservable()
     }
     

--- a/Projects/App/Sources/Domain/UseCases/AuthUseCase/Sources/DropOutUseCaseImpl.swift
+++ b/Projects/App/Sources/Domain/UseCases/AuthUseCase/Sources/DropOutUseCaseImpl.swift
@@ -14,17 +14,22 @@ public final class DropOutUseCaseImpl: DropOutUseCaseProtocol {
     private let userRepository: UserRepositoryProtocol
     private let plansRepository: PlansRepositoryProtocol
     private let friendRepository: FriendRepositoryProtocol
+    private let imageRepository: ImageRepositoryProtocol
     
-    public init(authRepository: AuthRepositoryProtocol, userRepository: UserRepositoryProtocol, plansRepository: PlansRepositoryProtocol, friendRepository: FriendRepositoryProtocol) {
+    public init(authRepository: AuthRepositoryProtocol, userRepository: UserRepositoryProtocol, plansRepository: PlansRepositoryProtocol, friendRepository: FriendRepositoryProtocol, imageRepository: ImageRepositoryProtocol) {
         self.authRepository = authRepository
         self.userRepository = userRepository
         self.plansRepository = plansRepository
         self.friendRepository = friendRepository
+        self.imageRepository = imageRepository
     }
     
     public func dropOut() -> Observable<Void> {
-        return self.friendRepository.deleteFriendsWhenDeleteUserInfo()
-            .asObservable()
+        return self.imageRepository.deleteMyProfileImage()
+            .withUnretained(self)
+            .flatMap { owner, _ in
+                owner.friendRepository.deleteFriendsWhenDeleteUserInfo()
+            }
             .withUnretained(self)
             .flatMap({ owner, _ in
                 owner.userRepository.deleteUserInfo()

--- a/Projects/App/Sources/Domain/UseCases/ImageUseCase/Interface/DeleteImageUseCaseProtocol.swift
+++ b/Projects/App/Sources/Domain/UseCases/ImageUseCase/Interface/DeleteImageUseCaseProtocol.swift
@@ -1,0 +1,14 @@
+//
+//  DeleteImageUseCaseProtocol.swift
+//  Moyeoraa
+//
+//  Created by 김요한 on 5/9/24.
+//  Copyright © 2024 com.moyeora. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+public protocol DeleteImageUseCaseProtocol {
+    func delete(imageString: String?) -> Observable<Void>
+}

--- a/Projects/App/Sources/Domain/UseCases/ImageUseCase/Sources/DeleteImageUseCaseImpl.swift
+++ b/Projects/App/Sources/Domain/UseCases/ImageUseCase/Sources/DeleteImageUseCaseImpl.swift
@@ -1,0 +1,26 @@
+//
+//  DeleteImageUseCaseImpl.swift
+//  Moyeoraa
+//
+//  Created by 김요한 on 5/9/24.
+//  Copyright © 2024 com.moyeora. All rights reserved.
+//
+
+import Foundation
+import RxSwift
+
+public final class DeleteImageUseCaseImpl: DeleteImageUseCaseProtocol {
+    private let imageRepository: ImageRepositoryProtocol
+    
+    public init(imageRepository: ImageRepositoryProtocol) {
+        self.imageRepository = imageRepository
+    }
+    
+    public func delete(imageString: String?) -> Observable<Void> {
+        guard let imageString else { return Observable.just(()) }
+        
+        return self.imageRepository.deleteImage(imageString: imageString)
+    }
+    
+    
+}

--- a/Projects/App/Sources/Feature/ChatFeature/Sources/View/UserAnnotationView.swift
+++ b/Projects/App/Sources/Feature/ChatFeature/Sources/View/UserAnnotationView.swift
@@ -34,7 +34,7 @@ public final class UserAnnotationView: MKAnnotationView, MKAnnotation {
         super.prepareForReuse()
         self.userID = nil
         self.userImageURLString = nil
-        self.imageView.removeFromSuperview()
+        self.imageView.bindImage(urlString: "")
     }
     
     private func configureAttributes() {

--- a/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/EditProfileCoordinator.swift
+++ b/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/EditProfileCoordinator.swift
@@ -38,13 +38,15 @@ public final class EditProfileCoordinator: CoordinatorProtocol {
         let fetchUserUseCase = FetchUserUseCaseImpl(userRepository: userRepository)
         let updateUserUseCase = UpdateUserUseCaseImpl(userRepository: userRepository)
         let uploadImageUseCase = UploadImageUseCaseImpl(imageRepository: imageRepository)
+        let deleteImageUseCase = DeleteImageUseCaseImpl(imageRepository: imageRepository)
 //        let fetchUserUseCase = FetchUserUseCaseSpy()
 //        let updateUserUseCase = UpdateUserUseCaseSpy()
 //        let uploadImageUseCase = UploadImageUseCaseSpy()
         let vm = EditProfileViewModel(
             fetchUserUseCase: fetchUserUseCase,
             updateUserUseCase: updateUserUseCase,
-            uploadImageUseCase: uploadImageUseCase
+            uploadImageUseCase: uploadImageUseCase, 
+            deleteImageUseCase: deleteImageUseCase
         )
         
         vm.setAction(EditProfileViewModelActions(finishEditProfileFeature: finishEditProfileFeature))

--- a/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
+++ b/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/MyPageCoordinator.swift
@@ -33,15 +33,12 @@ public final class MyPageCoordinator: CoordinatorProtocol {
         let userRepository = UserRepositoryImpl(firebaseService: firebaseService, tokenManager: tokenManager)
         let plansRepository = PlansRepositoryImpl(firebaseService: firebaseService, tokenManager: tokenManager)
         let friendRepository = FriendRepositoryImpl(fireBaseService: firebaseService, tokenManager: tokenManager)
+        let imageRepository = ImageRepositoryImpl(fireBaseService: firebaseService, tokenManager: tokenManager)
         
         let signOutUseCase = SignOutUseCaseImpl(authRepository: authRepository)
         let fetchUserUseCase = FetchUserUseCaseImpl(userRepository: userRepository)
         let updateNotificationUseCase = UpdateNotificationUseCaseSpy()
-        let dropOutUseCase = DropOutUseCaseImpl(authRepository: authRepository, userRepository: userRepository, plansRepository: plansRepository, friendRepository: friendRepository)
-        
-//        let fetchUserUseCase = FetchUserUseCaseSpy()
-//        let signOutUseCase = SignOutUseCaseSpy()
-//        let dropOutUseCase = DropOutUseCaseSpy()
+        let dropOutUseCase = DropOutUseCaseImpl(authRepository: authRepository, userRepository: userRepository, plansRepository: plansRepository, friendRepository: friendRepository, imageRepository: imageRepository)
         
         let vm = MyPageViewModel(
             fetchUserUseCase: fetchUserUseCase,

--- a/Projects/App/Sources/Feature/PlansDetailFeature/Sources/ViewModel/ModifyPlansViewModel.swift
+++ b/Projects/App/Sources/Feature/PlansDetailFeature/Sources/ViewModel/ModifyPlansViewModel.swift
@@ -64,11 +64,8 @@ public final class ModifyPlansViewModel: BaseViewModel {
     }
     
     public func trnasform(input: Input) -> Output {
-        let plans = input.viewDidAppear
-            .withUnretained(self)
-            .flatMap { owner, _ in
-                owner.fetchPlansUseCase.fetch(id: owner.plansID)
-            }
+        let plans = self.fetchPlansUseCase
+            .fetch(id: self.plansID)
             .do { [weak self] plans in
                 self?.titleText.accept(plans.title)
                 self?.selectedDate.accept(plans.date)

--- a/Projects/App/Sources/Shared/FoundationUtilities/Sources/String+.swift
+++ b/Projects/App/Sources/Shared/FoundationUtilities/Sources/String+.swift
@@ -22,4 +22,12 @@ public extension String {
     static var errorDetected: String {
         return "오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
     }
+    
+    func extractFilePath() -> String? {
+        guard let url = URL(string: self),
+              let pathComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)?.path.components(separatedBy: "/") else {
+            return nil
+        }
+        return pathComponents.last
+    }
 }


### PR DESCRIPTION
## PR 요약

## 작업한 브랜치
- feature/bugfix

## 작업한 내용
이미지 삭제 기능 추가, 약속 수정에서 맴버 추가뷰에서 넘어올 때 맴버들이 다시 사라지는 문제 수정, 
회원 탈퇴 시 프로필사진 삭제 누락 된 문제 수정, LocationShare 중 맵에 해당 유저 위치 데이터는 받지만 AnnotationView가 안보이는 문제 수정, 
회원탈퇴 이후 바로 회원가입하면 fcm 토큰이 없어 회원가입이 안되는 문제는 현재 해결 못함,
LocationShareFeature UserAnnotationView Set, Observe 로직 변경 
## 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 비고
회원 탈퇴후에 로그인뷰로 다시 가면 앱델리게이트에 구현한 fcm토큰 받아오고, 저장하는거 안해버려서 바로 회원가입 못하네 어떻게 보완 가능한지 모르겟다 유즈케이스를 다시 만들어야하나 싶네
유저어노테이션뷰 리유즈에다 removesubview를 해버려서 안보이는건데 엄한데서 이유 찾고 잇엇다 

## 관련 이슈
- Resolved: #84 
- Resolved: #83 
- Resolved: #82 
- Resolved: #78 
- Resolved: #77 
