### PR TITLE
[Feat, Fix] HomeFeature fetchPlansArr 로직 수정, CalendarView 데코레이션 바인딩 구현, CollectionView 밑에 마진 추가 

### DIFF
--- a/Projects/App/Sources/Data/Repositories/PlansRepository/Sources/PlansRepositoryImpl.swift
+++ b/Projects/App/Sources/Data/Repositories/PlansRepository/Sources/PlansRepositoryImpl.swift
@@ -66,6 +66,7 @@ public final class PlansRepositoryImpl: PlansRepositoryProtocol {
             .map { 
                 $0.compactMap { $0.toObject(PlansDTO.self)?.toEntity() }
             }
+            .debug("fetchPlansArr()")
     }
     
     public func fetchPlansArr(date: Date) -> Observable<[Plans]> {

--- a/Projects/App/Sources/Domain/UseCases/PlansUseCase/Interface/FetchPlansUseCaseProtocol.swift
+++ b/Projects/App/Sources/Domain/UseCases/PlansUseCase/Interface/FetchPlansUseCaseProtocol.swift
@@ -13,4 +13,5 @@ public protocol FetchPlansUseCaseProtocol {
     func fetch(date: Observable<Date>) -> Observable<[Plans]>
     func fetch(id: String) -> Observable<Plans>
     func fetch(chatRoomID: String) -> Observable<Plans>
+    func fetch() -> Observable<[Plans]> 
 }

--- a/Projects/App/Sources/Domain/UseCases/PlansUseCase/Sources/FetchPlansUseCaseImpl.swift
+++ b/Projects/App/Sources/Domain/UseCases/PlansUseCase/Sources/FetchPlansUseCaseImpl.swift
@@ -31,5 +31,8 @@ public final class FetchPlansUseCaseImpl: FetchPlansUseCaseProtocol {
         self.plansRepository.fetchPlans(chatRoomID: chatRoomID)
     }
     
+    public func fetch() -> Observable<[Plans]> {
+        self.plansRepository.fetchPlansArr()
+    }
 }
 

--- a/Projects/App/Sources/Domain/UseCases/PlansUseCase/Testing/FetchPlansUseCaseSpy.swift
+++ b/Projects/App/Sources/Domain/UseCases/PlansUseCase/Testing/FetchPlansUseCaseSpy.swift
@@ -37,6 +37,12 @@ public final class FetchPlansUseCaseSpy: FetchPlansUseCaseProtocol {
         
         return Observable.just(plans)
     }
+    
+    public func fetch() -> Observable<[Plans]> {
+        return Observable.just([])
+    }
+    
+    
 }
 
 private extension FetchPlansUseCaseSpy {

--- a/Projects/App/Sources/Feature/HomeFeature/Sources/ViewController/HomeFeature.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Sources/ViewController/HomeFeature.swift
@@ -167,7 +167,7 @@ public final class HomeFeature: BaseFeature {
         )
         let output = self.viewModel.trnasform(input: input)
         
-        output.Plans.drive(with: self) { owner, plansArr in
+        output.plansArrInDate.drive(with: self) { owner, plansArr in
             owner.emptyView.bindEmptyView(isEmpty: plansArr.isEmpty)
             
             let snap = owner.setSnapshot(plans: plansArr)
@@ -176,6 +176,13 @@ public final class HomeFeature: BaseFeature {
             owner.plansCollectionView.reloadData()
         }
         .disposed(by: self.disposeBag)
+        
+        output.plansArrIHad
+            .map({ $0.map { $0.date } })
+            .drive(with: self, onNext: { owner, dates in
+                owner.calendarView.bindCalendarView(plans: dates)
+            })
+            .disposed(by: self.disposeBag)
     }
 }
 

--- a/Projects/App/Sources/Feature/HomeFeature/Sources/ViewController/HomeFeature.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Sources/ViewController/HomeFeature.swift
@@ -137,7 +137,7 @@ public final class HomeFeature: BaseFeature {
             make.leading.equalTo(self.calendarView.snp.leading)
             make.trailing.equalTo(self.calendarView.snp.trailing)
             make.height.greaterThanOrEqualTo(300)
-            make.bottom.equalToSuperview()
+            make.bottom.equalToSuperview().offset(-56)
         }
         
         self.emptyView.snp.makeConstraints { make in
@@ -172,8 +172,8 @@ public final class HomeFeature: BaseFeature {
             
             let snap = owner.setSnapshot(plans: plansArr)
             owner.dataSource?.apply(snap)
-            owner.updateScrollViewContentSize()
             owner.plansCollectionView.reloadData()
+            owner.updateScrollViewContentSize()
         }
         .disposed(by: self.disposeBag)
         
@@ -190,13 +190,29 @@ private extension HomeFeature {
     func updateScrollViewContentSize() {
         let collectionViewHeight = self.plansCollectionView.contentSize.height
         let contentViewHeight = self.contentView.frame.height
-        // 24는 label과 plansCollectionView 패딩, 8은 calendarView 위 여백
+        // 24는 label과 plansCollectionView 패딩, 8은 calendarView 위 여백, 56은 콜렉션뷰 밑 마진
         let totalHeight = collectionViewHeight + contentViewHeight
-        + 24 + 8
-        
-        scrollView.contentSize = CGSize(width: scrollView.frame.width, height: totalHeight)
-        containerView.frame = CGRect(x: 0, y: 0, width: scrollView.frame.width, height: totalHeight)
-        
+        + 24 + 8 + 56
+        self.scrollView.contentSize = CGSize(width: self.scrollView.frame.width, height: totalHeight)
+        self.containerView.frame = CGRect(x: 0, y: 0, width: self.scrollView.frame.width, height: totalHeight)
+        self.configureCollectionView(collectionViewHeight)
+        self.configureContainerView(totalHeight)
+    }
+    
+    func configureCollectionView(_ height: CGFloat) {
+        self.plansCollectionView.snp.updateConstraints { make in
+            make.height.greaterThanOrEqualTo(height)
+            make.bottom.equalToSuperview().offset(-56)
+        }
+        self.plansCollectionView.reloadData()
+    }
+    
+    func configureContainerView(_ height: CGFloat) {
+        self.containerView.snp.updateConstraints { make in
+            make.height.greaterThanOrEqualTo(height)
+            make.bottom.equalToSuperview()
+        }
+        self.view.layoutIfNeeded()
     }
     
     func generateDataSource() -> UICollectionViewDiffableDataSource<Int, Plans> {

--- a/Projects/App/Sources/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -34,19 +34,29 @@ public final class HomeViewModel: BaseViewModel {
     }
     
     public struct Output {
-        let Plans: Driver<[Plans]>
+        let plansArrInDate: Driver<[Plans]>
+        let plansArrIHad: Driver<[Plans]>
     }
     
     public func trnasform(input: Input) -> Output {
         let selectedDate = input.calendarViewSelectedDate.share()
         
-        let plans = input.viewDidAppear
-            .debug("viewDidAppear")
+        let viewDidAppear = input.viewDidAppear.share()
+        
+        let plansArrIHad = viewDidAppear
+            .debug("plansArrIHad")
             .withUnretained(self)
             .flatMap { owner, _ -> Observable<[Plans]> in
-                owner.fetchPlansUseCase.fetch(date: selectedDate)
+                owner.fetchPlansUseCase.fetch()
             }
-            .asDriver(onErrorJustReturn: [])
+        
+        let plansArrInDate = Observable.combineLatest(plansArrIHad, selectedDate)
+            .debug("plansArrInDate")
+            .withUnretained(self)
+            .map { owner, val in
+                let (plansArr, date) = val
+                return owner.filterPlansArrInDate(plansArr: plansArr, selectedDate: date)
+            }
         
         input.plansDidSelect
 //            .debug("plansDidSelect")
@@ -63,11 +73,22 @@ public final class HomeViewModel: BaseViewModel {
             .disposed(by: self.disposeBag)
         
         
-        return Output(Plans: plans)
+        return Output(plansArrInDate: plansArrInDate.asDriver(onErrorJustReturn: []), plansArrIHad: plansArrIHad.asDriver(onErrorJustReturn: []))
     }
     
     public func setAction(_ actions: HomeViewModelActions) {
         self.actions = actions
     }
     
+}
+
+private extension HomeViewModel {
+    func filterPlansArrInDate(plansArr: [Plans], selectedDate: Date) -> [Plans] {
+        return plansArr.filter { plans in
+            let dateString = plans.date.toStringWithCustomFormat(.yearToDay)
+            let selectedDateString = selectedDate.toStringWithCustomFormat(.yearToDay)
+            
+            return selectedDateString == dateString
+        }
+    }
 }

--- a/Projects/App/Sources/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
+++ b/Projects/App/Sources/Feature/HomeFeature/Sources/ViewModel/HomeViewModel.swift
@@ -44,14 +44,14 @@ public final class HomeViewModel: BaseViewModel {
         let viewDidAppear = input.viewDidAppear.share()
         
         let plansArrIHad = viewDidAppear
-            .debug("plansArrIHad")
+//            .debug("plansArrIHad")
             .withUnretained(self)
             .flatMap { owner, _ -> Observable<[Plans]> in
                 owner.fetchPlansUseCase.fetch()
             }
         
         let plansArrInDate = Observable.combineLatest(plansArrIHad, selectedDate)
-            .debug("plansArrInDate")
+//            .debug("plansArrInDate")
             .withUnretained(self)
             .map { owner, val in
                 let (plansArr, date) = val

--- a/Projects/App/Sources/UserInterface/DesignSystem/Sources/Views/Views/MYRCalendarView.swift
+++ b/Projects/App/Sources/UserInterface/DesignSystem/Sources/Views/Views/MYRCalendarView.swift
@@ -80,8 +80,26 @@ private extension MYRCalendarView {
 public extension MYRCalendarView {
     func bindCalendarView(plans: [Date]) {
         self.hadPlans = plans
+        self.reloadCalendarView()
     }
     
+    func reloadCalendarView() {
+        // hadPlans 배열에서 DateComponents 배열로 변환
+        let dict = Dictionary(grouping: self.hadPlans) { date in
+            date.toStringWithCustomFormat(.yearToDay)
+        }
+        
+        print("dict::: \(dict)") 
+        let components = dict.map { key, dates -> DateComponents in
+            guard let date = Date().stringToDate(dateString: key, type: .yearToDay)
+            else { return DateComponents() }
+            print("date::: \(date)")
+            return self.calendar.dateComponents([.year, .month, .day], from: date)
+        }
+        
+        // 변환된 DateComponents 배열을 사용하여 데코레이션 다시 로드 // 해당 날짜가 해셔블하지 아니하면 페이탈 에러
+        self.calendarView.reloadDecorations(forDateComponents: components, animated: true)
+    }
 }
 
 extension MYRCalendarView: UICalendarViewDelegate, UICalendarSelectionSingleDateDelegate {


### PR DESCRIPTION
## PR 요약

## 작업한 브랜치
- feature/homefeature

## 작업한 내용
캘랜더뷰에 내가 속한 약속들이 나오도록 데코레이션 추가
기존 약속 패치받는 로직은 해당 날짜만 받아오는거였는데 데코레이션을 추가해야하므로 약속들을 전부 받아오고 달력 탭시 해당 날짜에 맞는 약속만 필터하여 콜렉션뷰에 표시 하도록 변경

콜렉션뷰 셀이 4개 이상이면 잘려서 나오는 문제가 있어 필터된 약속을 방출할 때마다 레이아웃을 업데이트하도록 수정

콜렉션뷰 밑에 바로 바텀바라서 답답한 느낌을 줘 마진을 추가하여 해소
## 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 비고

## 관련 이슈
- Resolved: #98 
- Resolved: #97 
- Resolved: #96 
- Resolved: #99
