### PR TITLE
[Feat] 토스트뷰 키보드위로 안올라가져서 일단 뒤로 미루고 알림뷰로 대체

### DIFF
--- a/Projects/App/Sources/Feature/ChatFeature/Sources/ViewController/ChatDetailFeature.swift
+++ b/Projects/App/Sources/Feature/ChatFeature/Sources/ViewController/ChatDetailFeature.swift
@@ -89,8 +89,7 @@ public final class ChatDetailFeature: BaseFeature {
         
         output.toastTrigger
             .drive(with: self) { owner, _ in
-                let toastView = MYRToastView(type: .failure, message: "위치 공유는 약속 당일에만 이용할 수 있습니다.", followsUndockedKeyboard: false)
-                toastView.show(in: self.view)
+                owner.showLocationShareFailedAlert()
             }
             .disposed(by: self.disposeBag)
     }
@@ -160,6 +159,18 @@ private extension ChatDetailFeature {
         }
         
         alert.addActions([cancel, logout])
+        
+        present(alert, animated: true, completion: nil)
+    }
+    
+    func showLocationShareFailedAlert() {
+        let alert = MYRAlertController(
+            title: "맴버 위치 공유",
+            message: "위치 공유는 약속 당일에만 이용할 수 있습니다.",
+            preferredStyle: .alert
+        )
+        let cancel = UIAlertAction(title: "확인", style: .cancel)
+        alert.addActions([cancel])
         
         present(alert, animated: true, completion: nil)
     }


### PR DESCRIPTION
## PR 요약

## 작업한 브랜치
- feature/toastview

## 작업한 내용
토스트뷰 키보드 위로 생성이 안되서 해결하다 안되서 뒤로 미루고 알림뷰로 대체하기로 함
## 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 비고

## 관련 이슈
- Resolved: #
