### PR TITLE
[Fix] 하위 뷰 푸쉬할때 바텀 바 사라지게 수정

### DIFF
--- a/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/BlockUserCoordinator.swift
+++ b/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/BlockUserCoordinator.swift
@@ -49,6 +49,7 @@ public final class BlockUserCoordinator: CoordinatorProtocol {
         )
         
         let vc = BlockUserFeature(viewModel: vm)
+        vc.hidesBottomBarWhenPushed = true
         
         self.navigation.pushViewController(vc, animated: true)
     }

--- a/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/FriendsCoordinator.swift
+++ b/Projects/App/Sources/Feature/MyPageFeature/Sources/Coordinator/FriendsCoordinator.swift
@@ -57,6 +57,7 @@ public final class FriendsCoordinator: CoordinatorProtocol {
         )
         
         let vc = FriendsFeature(viewModel: vm)
+        vc.hidesBottomBarWhenPushed = true
         
         self.navigation.pushViewController(vc, animated: true)
     }


### PR DESCRIPTION
## PR 요약

## 작업한 브랜치
- feature/mypage

## 작업한 내용
FrinedFeature, BlockUserFeature 하위 뷰 푸쉬할때 바텀 바 사라지게 수정
## 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 비고

## 관련 이슈
- Resolved: #120
